### PR TITLE
Fix compilation error and update the clean rules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,8 @@ todo
 *.out
 t
 *.bak
+*.a
+*.img
+*.inc
+qemu.log
+userapps/appsbin/

--- a/Makefile
+++ b/Makefile
@@ -16,14 +16,12 @@ image:
 
 .PHONY: net
 net:
-	/usr/sbin/tunctl -t tap100
-	/usr/sbin/tunctl -t tap200
-	/sbin/ifconfig tap100 0.0.0.0 promisc up
-	/sbin/ifconfig tap200 0.0.0.0 promisc up
-	-/usr/local/bin/ovs-vsctl del-port br0 tap100 > /dev/null 2>&1
-	/usr/local/bin/ovs-vsctl add-port br0 tap100
+	sudo tunctl -t tap100
+	sudo tunctl -t tap200
+	sudo ifconfig tap100 0.0.0.0 promisc up
+	sudo ifconfig tap200 0.0.0.0 promisc up
 run: net
-	qemu-system-x86_64 --enable-kvm -cpu host -smp 4 -option-rom sgabios.bin \
+	sudo qemu-system-x86_64 --enable-kvm -cpu host -smp 4 -option-rom sgabios.bin \
 		-m 8192 -rtc base=localtime \
 		-monitor stdio -curses \
 		-drive file=image/disk.img,if=ide \
@@ -33,7 +31,7 @@ run: net
 #		-net nic,model=rtl8139,macaddr=52:54:00:12:34:61 -net tap,vlan=1,ifname=tap1,script=no \
 
 test: net
-	qemu-system-x86_64 --enable-kvm -cpu host -smp 4 -option-rom sgabios.bin \
+	sudo qemu-system-x86_64 --enable-kvm -cpu host -smp 4 -option-rom sgabios.bin \
 		-m 8192 -rtc base=localtime \
 		-monitor telnet:127.0.0.1:2048,server,nowait,ipv4 -curses \
 		-drive file=image/disk.img,if=ide \
@@ -43,7 +41,7 @@ test: net
 #		-net nic,model=rtl8139,macaddr=52:54:00:12:34:61 -net tap,vlan=1,ifname=tap1,script=no \
 
 server: net
-	qemu-system-x86_64 --enable-kvm -cpu host -smp 4 -option-rom sgabios.bin \
+	sudo qemu-system-x86_64 --enable-kvm -cpu host -smp 4 -option-rom sgabios.bin \
 		-m 4096 -rtc base=localtime \
 		--daemonize \
 		-drive file=image/disk.img,if=ide \
@@ -62,6 +60,8 @@ server: net
 clean:
 	cd kernel && make clean
 	cd userapps && make clean
+	-rm -f sizekernel.inc
+	-rm -f image/*
 
 disasm:
 	#objdump -D -b binary -mi386 -M x86-64 kernel/kernel.o 

--- a/kernel/Makefile
+++ b/kernel/Makefile
@@ -3,7 +3,7 @@ OBJC=printf.o pci.o rtl8139.o netcard.o arp.o arpcache.o ip.o icmp.o ip_routing.
 SOURCEC=$(OBJC:.o=.c)
 OBJASM=boot.o kernelmain.o interrupts.o scheduler.o helpers.o mutex.o mmu.o hardware.o apic.o intA0.o heap.o cmos.o vmx.o guest.o video_s.o timer.o
 SOURCEASM=$(OBJASM:.o=.S)
-CFLAGS=-fno-zero-initialized-in-bss -Wno-pointer-to-int-cast -ffreestanding -mcmodel=large -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-3dnow -Wimplicit-function-declaration -Werror=implicit-function-declaration
+CFLAGS=-fno-zero-initialized-in-bss -Wno-pointer-to-int-cast -ffreestanding -mcmodel=large -mno-red-zone -mno-mmx -mno-sse -mno-sse2 -mno-sse3 -mno-3dnow -Wimplicit-function-declaration -Werror=implicit-function-declaration -fno-pie
 PFLAGS=-DPCID
 
 .c.o:
@@ -21,5 +21,5 @@ kernel: $(OBJASM) $(OBJC)
 	wc -c < kernel.o >> ../sizekernel.inc
 	
 clean:
-	rm *.o	
+	-rm -f *.o	
 

--- a/userapps/Makefile
+++ b/userapps/Makefile
@@ -16,4 +16,5 @@ apps: systemlib $(BINS)
 
 clean:
 	 cd systemlib && make clean
-	 rm -Rf appsbin
+	 -rm -Rf appsbin
+	 -rm -f disk.img

--- a/userapps/systemlib/Makefile
+++ b/userapps/systemlib/Makefile
@@ -12,5 +12,5 @@ $(TARGET).a: $(OBJECTS)
 	ar rcs systemlib.a $(OBJECTS)
 
 clean:
-	-rm *.o
-	-rm *.a
+	-rm -f *.o
+	-rm -f *.a


### PR DESCRIPTION
 ## Summary of Changes

Add -fno-pie flag to the compilation to prevent undefined _GDT symbol
during compilation. Update the clean rules to prevent them from stopping
the clean procedure if a file is not found. Add the generated files to
.gitignore.

Signed-off-by: Sebastian Ene <sene@apache.org>